### PR TITLE
Fix: Use os.environ.get for STAGE in urls.py #148

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -19,9 +19,10 @@ urlpatterns = [
     url('^$', index, name='index'),
 ]
 
-if os.environ['STAGE'] == 'DEVL':
+_stage = os.environ.get('STAGE', '')
+if _stage == 'DEVL':
     urlpatterns += static(STATIC_URL)
-elif os.environ['STAGE'] == 'ALPHA':
+elif _stage == 'ALPHA':
     urlpatterns += static(STATIC_URL, document_root=os.path.join(BASE_DIR, 'static'))
-elif os.environ['STAGE'] == 'PROD':
+elif _stage == 'PROD':
     urlpatterns += static(STATIC_URL)


### PR DESCRIPTION
## Summary
- `os.environ['STAGE']`を`os.environ.get('STAGE', '')`に変更
- Lambda環境でSTAGE変数が未設定の場合のKeyErrorを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)