### PR TITLE
Fix: Make google imports optional in common.py #151

### DIFF
--- a/backend/settings/common.py
+++ b/backend/settings/common.py
@@ -1,10 +1,15 @@
 import io
 import os
 import environ
-import google.auth
-from google.cloud import secretmanager
 from sys import path
 from os.path import join
+
+try:
+    import google.auth
+    from google.cloud import secretmanager
+    _has_google = True
+except ImportError:
+    _has_google = False
 
 from django.urls import reverse_lazy
 
@@ -151,10 +156,11 @@ AWS_S3_FILE_OVERWRITE = False
 AWS_DEFAULT_ACL = None
 
 # Attempt to load the Project ID into the environment, safely failing on error.
-try:
-    _, os.environ["GOOGLE_CLOUD_PROJECT"] = google.auth.default()
-except google.auth.exceptions.DefaultCredentialsError:
-    pass
+if _has_google:
+    try:
+        _, os.environ["GOOGLE_CLOUD_PROJECT"] = google.auth.default()
+    except google.auth.exceptions.DefaultCredentialsError:
+        pass
 
 if os.getenv("TRAMPOLINE_CI", None):
     # Create local settings if running with CI, for unit testing
@@ -176,6 +182,9 @@ elif os.environ.get("GOOGLE_CLOUD_PROJECT", None):
     payload = client.access_secret_version(name=name).payload.data.decode("UTF-8")
 
     env.read_env(io.StringIO(payload))
+elif os.environ.get("DJANGO_SECRET_KEY", None):
+    # Running in AWS — secrets provided via environment variables directly
+    pass
 else:
     raise Exception("No local .env or GOOGLE_CLOUD_PROJECT detected. No secrets found.")
 


### PR DESCRIPTION
## Summary
- `common.py`の`google.auth`インポートを`try/except ImportError`でオプショナルに変更
- `DJANGO_SECRET_KEY`が設定されている場合（AWS環境）はGCP Secrets Managerをスキップ
- Lambda環境での`Runtime.ImportModuleError: No module named 'google'`を解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)