### PR TITLE
Fix: Guard DATABASES env.db() with DATABASE_URL check #152

### DIFF
--- a/backend/settings/common.py
+++ b/backend/settings/common.py
@@ -195,13 +195,15 @@ try:
 except:
     DEBUG = False
 
-DATABASES = {
-    'default': env.db()
-}
-
-if os.getenv("USE_CLOUD_SQL_AUTH_PROXY", None):
-    DATABASES["default"]["HOST"] = "127.0.0.1"
-    DATABASES["default"]["PORT"] = 8100
+if os.environ.get("DATABASE_URL"):
+    DATABASES = {
+        'default': env.db()
+    }
+    if os.getenv("USE_CLOUD_SQL_AUTH_PROXY", None):
+        DATABASES["default"]["HOST"] = "127.0.0.1"
+        DATABASES["default"]["PORT"] = 8100
+else:
+    DATABASES = {}
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
## Summary
- `DATABASE_URL`が未設定の場合は`env.db()`をスキップ
- AWS Lambdaでは`aws.py`が`DB_HOST`等の個別環境変数から`DATABASES`を設定するため
- Lambda起動時の`ImproperlyConfigured: Set the DATABASE_URL environment variable`を解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)