### PR TITLE
Fix: Use ASGI handler for Mangum compatibility #153

### DIFF
--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings.aws")
+
+application = get_asgi_application()

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -3,6 +3,6 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings.aws")
 
 from mangum import Mangum
-from backend.wsgi import application
+from backend.asgi import application
 
 handler = Mangum(application, lifespan="off")


### PR DESCRIPTION
## Summary
- `backend/asgi.py`を新規作成（Django標準の`get_asgi_application()`を使用）
- `lambda_handler.py`を`backend.wsgi`→`backend.asgi`に変更
- Mangum 0.17+ はASGIのみサポートのため、WSSGIアプリを直接渡すと`TypeError`が発生していた

🤖 Generated with [Claude Code](https://claude.com/claude-code)