### PR TITLE
Fix: Make firebase_admin import optional #155

### DIFF
--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -5,8 +5,12 @@ import json
 import asyncio
 import traceback
 
-import firebase_admin
-from firebase_admin import credentials
+try:
+    import firebase_admin
+    from firebase_admin import credentials
+    _has_firebase = True
+except ImportError:
+    _has_firebase = False
 
 from django.utils.timezone import datetime, timedelta
 


### PR DESCRIPTION
## Summary
- `users/views.py`の`firebase_admin`インポートを`try/except ImportError`でオプショナルに変更
- `GCPAccessTokenView`のみで使用。AWS環境では不要
- Lambda起動時の`ModuleNotFoundError: No module named 'firebase_admin'`を解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)