### PR TITLE
Fix: Me view returns 401 not 404 when unauthenticated #158

### DIFF
--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -78,7 +78,7 @@ class Me(View):
         else:
             return JsonResponse(data={
                 "message": "not authenticated"
-            }, status=404)
+            }, status=401)
 
 class MailGenerator:
     @staticmethod


### PR DESCRIPTION
## Summary
- `Me`ビューが未認証時に404を返していたため、CloudFrontの`custom_error_response`(404→200+index.html)に捕まっていた
- 401に変更することでCloudFrontがそのまま通過させ、フロントエンドが正しく未認証状態を検知できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)